### PR TITLE
Add list of banned cards and tags for Badlatro ruleset

### DIFF
--- a/content/docs/rulesets/badlatro.mdx
+++ b/content/docs/rulesets/badlatro.mdx
@@ -3,4 +3,65 @@ title: Badlatro
 description: A special weekly ruleset that the community liked, so we are bringing it back permanently. Includes 43 banned cards and 5 banned tags.
 ---
 
-The list of banned cards and tags is coming soon.
+## Banned Jokers
+
+- Canio
+- Perkeo
+- Triboulet
+- Yorick
+- Blueprint
+- Ancient Joker
+- Baron
+- Baseball Card
+- DNA
+- The Family
+- The Trio
+- Vagabond
+- Acrobat
+- Card Sharp
+- Cartomancer
+- Certificate
+- Dusk
+- Fibonacci
+- Hologram
+- Loyalty Card
+- Lucky Cat
+- Midas Mask
+- Bloodstone
+- Arrowhead
+- Onyx Agate
+- Seltzer
+- Trading Card
+- Abstract Joker
+- Blue Joker
+- Cavendish
+- Photograph
+- Hanging Chad
+- Mail-In Rebate
+- Brainstorm
+- Mime
+- Steel Joker
+- Reserved Parking
+- Defensive Joker
+
+## Banned Consumables
+
+- Justice
+- Deja Vu
+- Trance
+
+## Banned Vouchers
+
+- Magic Trick
+
+## Banned Enhancements
+
+- Glass
+
+## Banned Tags
+
+- Uncommon Joker
+- Meteor
+- Garbage
+- Top Up
+- Handy


### PR DESCRIPTION
Adding the list of banned cards and tags for the Badlatro ruleset. I couldn't test locally due to some weird Fumadocs error (`replaceOrDefault` missing?) but this should work with the MDX structure. Let me know if any formatting adjustments are needed!