### PR TITLE
Add Smallworld filter to match history type dropdown

### DIFF
--- a/src/app/(home)/players/[id]/user.tsx
+++ b/src/app/(home)/players/[id]/user.tsx
@@ -549,6 +549,7 @@ function UserInfoComponent() {
                     <SelectItem value='all'>All Leaderboards</SelectItem>
                     <SelectItem value='ranked'>Ranked</SelectItem>
                     <SelectItem value='vanilla'>Vanilla</SelectItem>
+                    <SelectItem value='smallworld'>Smallworld</SelectItem>
                   </SelectContent>
                 </Select>
               </div>


### PR DESCRIPTION
Originally only had ranked and vanilla filters, it seemed that the logic to filter smallworld was already in place but there was not select option.