### PR TITLE
feat(banned-users): soft vs hard (connection) bans

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -8,7 +8,7 @@
   "files": {
     "maxSize": 3145728,
     "ignoreUnknown": false,
-    "includes": ["**"]
+    "includes": ["**", "!drizzle"]
   },
   "formatter": {
     "enabled": true,

--- a/drizzle/0013_add_banned_user_ban_type.sql
+++ b/drizzle/0013_add_banned_user_ban_type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "banned_users" ADD COLUMN "ban_type" text DEFAULT 'soft' NOT NULL;

--- a/drizzle/meta/0013_snapshot.json
+++ b/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,2209 @@
+{
+  "id": "2752177c-386a-40b5-94f9-83920b935196",
+  "prevId": "5c4f3f7f-d7a5-4686-a96b-433feebf7723",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "name": "account_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banned_user_aliases": {
+      "name": "banned_user_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "banned_user_aliases_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "banned_user_id": {
+          "name": "banned_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias_lower": {
+          "name": "alias_lower",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "banned_user_aliases_alias_lower_idx": {
+          "name": "banned_user_aliases_alias_lower_idx",
+          "columns": [
+            {
+              "expression": "alias_lower",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "banned_user_aliases_user_alias_unique": {
+          "name": "banned_user_aliases_user_alias_unique",
+          "columns": [
+            {
+              "expression": "banned_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias_lower",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "banned_user_aliases_banned_user_id_banned_users_id_fk": {
+          "name": "banned_user_aliases_banned_user_id_banned_users_id_fk",
+          "tableFrom": "banned_user_aliases",
+          "tableTo": "banned_users",
+          "columnsFrom": [
+            "banned_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banned_user_ids": {
+      "name": "banned_user_ids",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "banned_user_ids_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "banned_user_id": {
+          "name": "banned_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_lower": {
+          "name": "value_lower",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "banned_user_ids_value_lower_idx": {
+          "name": "banned_user_ids_value_lower_idx",
+          "columns": [
+            {
+              "expression": "value_lower",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "banned_user_ids_user_value_unique": {
+          "name": "banned_user_ids_user_value_unique",
+          "columns": [
+            {
+              "expression": "banned_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value_lower",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "banned_user_ids_banned_user_id_banned_users_id_fk": {
+          "name": "banned_user_ids_banned_user_id_banned_users_id_fk",
+          "tableFrom": "banned_user_ids",
+          "tableTo": "banned_users",
+          "columnsFrom": [
+            "banned_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banned_users": {
+      "name": "banned_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "banned_users_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ban_type": {
+          "name": "ban_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'soft'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blog_posts": {
+      "name": "blog_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "blog_posts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blog_posts_author_id_user_id_fk": {
+          "name": "blog_posts_author_id_user_id_fk",
+          "tableFrom": "blog_posts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "blog_posts_slug_unique": {
+          "name": "blog_posts_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mod_branches": {
+      "name": "mod_branches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "mod_branches_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mod_branches_name_unique": {
+          "name": "mod_branches_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "games_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "log_file_id": {
+          "name": "log_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_index": {
+          "name": "game_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest": {
+          "name": "guest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_owner_name": {
+          "name": "log_owner_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opponent_name": {
+          "name": "opponent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_host": {
+          "name": "is_host",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_connection_id": {
+          "name": "host_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_connection_id": {
+          "name": "guest_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_encrypt_id": {
+          "name": "host_encrypt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_encrypt_id": {
+          "name": "guest_encrypt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deck": {
+          "name": "deck",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seed": {
+          "name": "seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stake": {
+          "name": "stake",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ruleset": {
+          "name": "ruleset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "options": {
+          "name": "options",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "winner": {
+          "name": "winner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "money_gained": {
+          "name": "money_gained",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "money_spent": {
+          "name": "money_spent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opponent_money_spent": {
+          "name": "opponent_money_spent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rerolls": {
+          "name": "rerolls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reroll_cost_total": {
+          "name": "reroll_cost_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opponent_rerolls": {
+          "name": "opponent_rerolls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opponent_reroll_cost_total": {
+          "name": "opponent_reroll_cost_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_owner_final_jokers": {
+          "name": "log_owner_final_jokers",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opponent_final_jokers": {
+          "name": "opponent_final_jokers",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "log_owner_vouchers": {
+          "name": "log_owner_vouchers",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opponent_vouchers": {
+          "name": "opponent_vouchers",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "games_log_file_id_idx": {
+          "name": "games_log_file_id_idx",
+          "columns": [
+            {
+              "expression": "log_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "games_host_idx": {
+          "name": "games_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "games_guest_idx": {
+          "name": "games_guest_idx",
+          "columns": [
+            {
+              "expression": "guest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "games_host_connection_id_idx": {
+          "name": "games_host_connection_id_idx",
+          "columns": [
+            {
+              "expression": "host_connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "games_guest_connection_id_idx": {
+          "name": "games_guest_connection_id_idx",
+          "columns": [
+            {
+              "expression": "guest_connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "games_host_encrypt_id_idx": {
+          "name": "games_host_encrypt_id_idx",
+          "columns": [
+            {
+              "expression": "host_encrypt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "games_guest_encrypt_id_idx": {
+          "name": "games_guest_encrypt_id_idx",
+          "columns": [
+            {
+              "expression": "guest_encrypt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "games_deck_idx": {
+          "name": "games_deck_idx",
+          "columns": [
+            {
+              "expression": "deck",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "games_seed_idx": {
+          "name": "games_seed_idx",
+          "columns": [
+            {
+              "expression": "seed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "games_stake_idx": {
+          "name": "games_stake_idx",
+          "columns": [
+            {
+              "expression": "stake",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "games_ruleset_idx": {
+          "name": "games_ruleset_idx",
+          "columns": [
+            {
+              "expression": "ruleset",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "games_winner_idx": {
+          "name": "games_winner_idx",
+          "columns": [
+            {
+              "expression": "winner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "games_start_date_idx": {
+          "name": "games_start_date_idx",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "games_log_file_id_game_index_unique": {
+          "name": "games_log_file_id_game_index_unique",
+          "columns": [
+            {
+              "expression": "log_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "game_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "games_log_file_id_log_files_id_fk": {
+          "name": "games_log_file_id_log_files_id_fk",
+          "tableFrom": "games",
+          "tableTo": "log_files",
+          "columnsFrom": [
+            "log_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.leaderboard_snapshots": {
+      "name": "leaderboard_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "leaderboard_snapshots_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.log_file_connections": {
+      "name": "log_file_connections",
+      "schema": "",
+      "columns": {
+        "log_file_id": {
+          "name": "log_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id_lower": {
+          "name": "connection_id_lower",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "log_file_connections_log_file_id_log_files_id_fk": {
+          "name": "log_file_connections_log_file_id_log_files_id_fk",
+          "tableFrom": "log_file_connections",
+          "tableTo": "log_files",
+          "columnsFrom": [
+            "log_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "log_file_connections_log_file_id_connection_id_lower_pk": {
+          "name": "log_file_connections_log_file_id_connection_id_lower_pk",
+          "columns": [
+            "log_file_id",
+            "connection_id_lower"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.log_file_lobby_codes": {
+      "name": "log_file_lobby_codes",
+      "schema": "",
+      "columns": {
+        "log_file_id": {
+          "name": "log_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lobby_code": {
+          "name": "lobby_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lobby_code_lower": {
+          "name": "lobby_code_lower",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "log_file_lobby_codes_log_file_id_log_files_id_fk": {
+          "name": "log_file_lobby_codes_log_file_id_log_files_id_fk",
+          "tableFrom": "log_file_lobby_codes",
+          "tableTo": "log_files",
+          "columnsFrom": [
+            "log_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "log_file_lobby_codes_log_file_id_lobby_code_lower_pk": {
+          "name": "log_file_lobby_codes_log_file_id_lobby_code_lower_pk",
+          "columns": [
+            "log_file_id",
+            "lobby_code_lower"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.log_file_owner_connections": {
+      "name": "log_file_owner_connections",
+      "schema": "",
+      "columns": {
+        "log_file_id": {
+          "name": "log_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id_lower": {
+          "name": "connection_id_lower",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "log_file_owner_connections_log_file_id_log_files_id_fk": {
+          "name": "log_file_owner_connections_log_file_id_log_files_id_fk",
+          "tableFrom": "log_file_owner_connections",
+          "tableTo": "log_files",
+          "columnsFrom": [
+            "log_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "log_file_owner_connections_log_file_id_connection_id_lower_pk": {
+          "name": "log_file_owner_connections_log_file_id_connection_id_lower_pk",
+          "columns": [
+            "log_file_id",
+            "connection_id_lower"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.log_file_players": {
+      "name": "log_file_players",
+      "schema": "",
+      "columns": {
+        "log_file_id": {
+          "name": "log_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_name_lower": {
+          "name": "player_name_lower",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "log_file_players_log_file_id_log_files_id_fk": {
+          "name": "log_file_players_log_file_id_log_files_id_fk",
+          "tableFrom": "log_file_players",
+          "tableTo": "log_files",
+          "columnsFrom": [
+            "log_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "log_file_players_log_file_id_player_name_lower_pk": {
+          "name": "log_file_players_log_file_id_player_name_lower_pk",
+          "columns": [
+            "log_file_id",
+            "player_name_lower"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.log_files": {
+      "name": "log_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "log_files_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parsed_json": {
+          "name": "parsed_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "log_files_file_hash_unique": {
+          "name": "log_files_file_hash_unique",
+          "columns": [
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "log_files_user_id_user_id_fk": {
+          "name": "log_files_user_id_user_id_fk",
+          "tableFrom": "log_files",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_logs": {
+      "name": "memory_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "memory_logs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heap_used_mb": {
+          "name": "heap_used_mb",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heap_total_mb": {
+          "name": "heap_total_mb",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rss_mb": {
+          "name": "rss_mb",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_mb": {
+          "name": "external_mb",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.metadata": {
+      "name": "metadata",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_games": {
+      "name": "player_games",
+      "schema": "",
+      "columns": {
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queue_id": {
+          "name": "queue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_time": {
+          "name": "game_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_type": {
+          "name": "game_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_num": {
+          "name": "game_num",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_mmr": {
+          "name": "player_mmr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mmr_change": {
+          "name": "mmr_change",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opponent_id": {
+          "name": "opponent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opponent_name": {
+          "name": "opponent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opponent_mmr": {
+          "name": "opponent_mmr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deck": {
+          "name": "deck",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stake": {
+          "name": "stake",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "game_num_per_player_idx": {
+          "name": "game_num_per_player_idx",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "game_num",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "season_idx": {
+          "name": "season_idx",
+          "columns": [
+            {
+              "expression": "season",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "player_games_player_id_game_num_pk": {
+          "name": "player_games_player_id_game_num_pk",
+          "columns": [
+            "player_id",
+            "game_num"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raw_history": {
+      "name": "raw_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "raw_history_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "game_num": {
+          "name": "game_num",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry": {
+          "name": "entry",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "game_num_unique_idx": {
+          "name": "game_num_unique_idx",
+          "columns": [
+            {
+              "expression": "game_num",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mod_release": {
+      "name": "mod_release",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "mod_release_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "smods_version": {
+          "name": "smods_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'latest'"
+        },
+        "lovely_version": {
+          "name": "lovely_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'latest'"
+        },
+        "branch_id": {
+          "name": "branch_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mod_release_branch_id_mod_branches_id_fk": {
+          "name": "mod_release_branch_id_mod_branches_id_fk",
+          "tableFrom": "mod_release",
+          "tableTo": "mod_branches",
+          "columnsFrom": [
+            "branch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.season_snapshots": {
+      "name": "season_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "season_snapshots_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queue_type": {
+          "name": "queue_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queue_id": {
+          "name": "queue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "minio_key": {
+          "name": "minio_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "season_snapshots_season_id_idx": {
+          "name": "season_snapshots_season_id_idx",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "season_snapshots_season_queue_unique": {
+          "name": "season_snapshots_season_queue_unique",
+          "columns": [
+            {
+              "expression": "season_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "queue_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "season_snapshots_season_id_seasons_id_fk": {
+          "name": "season_snapshots_season_id_seasons_id_fk",
+          "tableFrom": "season_snapshots",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seasons": {
+      "name": "seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "seasons_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "t_user_id_idx": {
+          "name": "t_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcripts": {
+      "name": "transcripts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "transcripts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "game_number": {
+          "name": "game_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "transcripts_game_number_unique": {
+          "name": "transcripts_game_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "game_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitch_url": {
+          "name": "twitch_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_url": {
+          "name": "youtube_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_token": {
+      "name": "verification_token",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_token_identifier_token_pk": {
+          "name": "verification_token_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1776179515486,
       "tag": "0012_good_may_parker",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1781600000000,
+      "tag": "0013_add_banned_user_ban_type",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(home)/admin/banned-users/banned-users-client.tsx
+++ b/src/app/(home)/admin/banned-users/banned-users-client.tsx
@@ -8,6 +8,16 @@ import { useDebounceCallback } from 'usehooks-ts'
 import { PaginationControls } from '@/app/_components/pagination-controls'
 import { SortableHeader } from '@/app/_components/sortable-header'
 import { TableShell } from '@/app/_components/table-shell'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -20,6 +30,7 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import {
   Table,
   TableBody,
@@ -31,9 +42,12 @@ import {
 import { Textarea } from '@/components/ui/textarea'
 import { api } from '@/trpc/react'
 
+type BanType = 'soft' | 'hard'
+
 type BannedUserEntry = {
   id: number
   label: string
+  banType: BanType
   aliases: string[]
   ids: string[]
   createdAt: Date
@@ -41,6 +55,14 @@ type BannedUserEntry = {
 }
 
 type SortBy = 'label' | 'updatedAt' | 'createdAt'
+
+function BanTypeBadge({ banType }: { banType: BanType }) {
+  return banType === 'hard' ? (
+    <Badge variant='destructive'>Hard ban</Badge>
+  ) : (
+    <Badge variant='secondary'>Soft ban</Badge>
+  )
+}
 
 function parseListInput(value: string) {
   const seen = new Set<string>()
@@ -84,7 +106,7 @@ function renderValueBadges(values: string[], emptyLabel: string) {
   )
 }
 
-export function BannedUsersClient() {
+export function BannedUsersClient({ canHardBan }: { canHardBan: boolean }) {
   const utils = api.useUtils()
   const pageSize = 50
   const [isDialogOpen, setIsDialogOpen] = useState(false)
@@ -92,6 +114,8 @@ export function BannedUsersClient() {
     null
   )
   const [label, setLabel] = useState('')
+  const [banType, setBanType] = useState<BanType>('soft')
+  const [hardConfirmOpen, setHardConfirmOpen] = useState(false)
   const [aliasesInput, setAliasesInput] = useState('')
   const [idsInput, setIdsInput] = useState('')
   const [queryParams, setQueryParams] = useQueryStates(
@@ -141,6 +165,7 @@ export function BannedUsersClient() {
 
     setSelectedEntry(refreshedEntry)
     setLabel(refreshedEntry.label)
+    setBanType(refreshedEntry.banType)
     setAliasesInput(refreshedEntry.aliases.join('\n'))
     setIdsInput(refreshedEntry.ids.join('\n'))
   }, [rows, selectedEntry])
@@ -149,6 +174,7 @@ export function BannedUsersClient() {
     setIsDialogOpen(false)
     setSelectedEntry(null)
     setLabel('')
+    setBanType('soft')
     setAliasesInput('')
     setIdsInput('')
   }, [])
@@ -190,13 +216,23 @@ export function BannedUsersClient() {
   )
   const idCount = useMemo(() => parseListInput(idsInput).length, [idsInput])
 
-  const handleSubmit = () => {
+  const doSave = () => {
     saveMutation.mutate({
       id: selectedEntry?.id,
       label,
+      banType,
       aliases: parseListInput(aliasesInput),
       ids: parseListInput(idsInput),
     })
+  }
+
+  const handleSubmit = () => {
+    // Hard bans cut off server access entirely — make the admin confirm.
+    if (banType === 'hard') {
+      setHardConfirmOpen(true)
+      return
+    }
+    doSave()
   }
 
   const handleDelete = (entry: BannedUserEntry) => {
@@ -232,6 +268,7 @@ export function BannedUsersClient() {
               setIsDialogOpen(true)
               setSelectedEntry(null)
               setLabel('')
+              setBanType('soft')
               setAliasesInput('')
               setIdsInput('')
             }}
@@ -284,7 +321,10 @@ export function BannedUsersClient() {
                   <TableRow key={entry.id}>
                     <TableCell>
                       <div className='flex flex-col gap-1'>
-                        <span className='font-medium'>{entry.label}</span>
+                        <div className='flex items-center gap-2'>
+                          <span className='font-medium'>{entry.label}</span>
+                          <BanTypeBadge banType={entry.banType} />
+                        </div>
                         <span className='text-muted-foreground text-xs'>
                           #{entry.id}
                         </span>
@@ -306,6 +346,7 @@ export function BannedUsersClient() {
                             setIsDialogOpen(true)
                             setSelectedEntry(entry)
                             setLabel(entry.label)
+                            setBanType(entry.banType)
                             setAliasesInput(entry.aliases.join('\n'))
                             setIdsInput(entry.ids.join('\n'))
                           }}
@@ -373,6 +414,54 @@ export function BannedUsersClient() {
             </div>
 
             <div className='grid gap-2'>
+              <Label>Ban type</Label>
+              <RadioGroup
+                value={banType}
+                onValueChange={(value) => setBanType(value as BanType)}
+                className='gap-3'
+              >
+                <div className='flex items-start gap-2'>
+                  <RadioGroupItem
+                    value='soft'
+                    id='ban-type-soft'
+                    className='mt-1'
+                  />
+                  <Label
+                    htmlFor='ban-type-soft'
+                    className='flex flex-col gap-0.5 font-normal'
+                  >
+                    <span className='font-medium'>Soft ban (default)</span>
+                    <span className='text-muted-foreground text-xs'>
+                      Notify only — we get a heads-up when they play, but they
+                      are NOT disconnected, so they don't know they're flagged.
+                    </span>
+                  </Label>
+                </div>
+                <div className='flex items-start gap-2'>
+                  <RadioGroupItem
+                    value='hard'
+                    id='ban-type-hard'
+                    className='mt-1'
+                    disabled={!canHardBan}
+                  />
+                  <Label
+                    htmlFor='ban-type-hard'
+                    className='flex flex-col gap-0.5 font-normal'
+                  >
+                    <span className='font-medium text-destructive'>
+                      Hard ban — blocks server access entirely
+                    </span>
+                    <span className='text-muted-foreground text-xs'>
+                      {canHardBan
+                        ? 'The relay disconnects this player from multiplayer completely. Use only to deny access outright.'
+                        : 'You do not have permission to issue hard bans.'}
+                    </span>
+                  </Label>
+                </div>
+              </RadioGroup>
+            </div>
+
+            <div className='grid gap-2'>
               <div className='flex items-center justify-between gap-2'>
                 <Label htmlFor='banned-user-aliases'>Aliases</Label>
                 <span className='text-muted-foreground text-xs'>
@@ -413,12 +502,44 @@ export function BannedUsersClient() {
             >
               Cancel
             </Button>
-            <Button onClick={handleSubmit} disabled={saveMutation.isPending}>
+            <Button
+              onClick={handleSubmit}
+              disabled={
+                saveMutation.isPending || (banType === 'hard' && !canHardBan)
+              }
+            >
               {saveMutation.isPending ? 'Saving...' : 'Save'}
             </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <AlertDialog open={hardConfirmOpen} onOpenChange={setHardConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Issue a hard (connection) ban?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This BLOCKS{' '}
+              <span className='font-medium'>{label || 'this user'}</span> from
+              connecting to the multiplayer server entirely — every alias and id
+              on this entry will be disconnected on sight. Only do this to deny
+              access outright.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className='bg-destructive text-white hover:bg-destructive/90'
+              onClick={() => {
+                setHardConfirmOpen(false)
+                doSave()
+              }}
+            >
+              Yes, hard ban
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/src/app/(home)/admin/banned-users/page.tsx
+++ b/src/app/(home)/admin/banned-users/page.tsx
@@ -20,6 +20,8 @@ export default async function BannedUsersPage() {
     redirect('/')
   }
 
+  const canHardBan = hasPermission(session?.user, 'banned_users.hard_ban')
+
   await api.bannedUsers.list.prefetch({
     page: 1,
     pageSize: 50,
@@ -32,7 +34,7 @@ export default async function BannedUsersPage() {
       <HydrateClient>
         <div className='mx-auto flex w-[calc(100%-1rem)] max-w-fd-container flex-col gap-4 pt-8'>
           <h1 className='font-bold text-3xl'>Banned Users</h1>
-          <BannedUsersClient />
+          <BannedUsersClient canHardBan={canHardBan} />
         </div>
       </HydrateClient>
     </Suspense>

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -2,6 +2,7 @@ export const PERMISSION_KEYS = [
   'permissions.manage',
   'seasons.manage',
   'banned_users.manage',
+  'banned_users.hard_ban',
   'moderation.view',
   'moderation.strikes.manage',
   'moderation.bans.manage',
@@ -63,6 +64,7 @@ export const LEGACY_ROLE_PERMISSIONS = {
     'permissions.manage',
     'seasons.manage',
     'banned_users.manage',
+    'banned_users.hard_ban',
     'moderation.view',
     'moderation.strikes.manage',
     'moderation.bans.manage',
@@ -114,6 +116,12 @@ export const PERMISSION_GROUPS: PermissionGroup[] = [
         key: 'banned_users.manage',
         label: 'Manage banned users',
         description: 'Open the banned users page and edit aliases and ids.',
+      },
+      {
+        key: 'banned_users.hard_ban',
+        label: 'Issue hard (connection) bans',
+        description:
+          'Mark a banned user as a HARD ban, which blocks them from connecting to the multiplayer server entirely. Without this, bans are soft (notify-only).',
       },
     ],
   },

--- a/src/server/api/routers/banned-users.ts
+++ b/src/server/api/routers/banned-users.ts
@@ -1,5 +1,7 @@
+import { TRPCError } from '@trpc/server'
 import { asc, desc, eq, sql } from 'drizzle-orm'
 import { z } from 'zod'
+import { hasPermission } from '@/lib/permissions'
 import { createTRPCRouter, permissionProcedure } from '@/server/api/trpc'
 import {
   listBannedUserRegistryEntries,
@@ -18,6 +20,7 @@ const saveBannedUserSchema = z
   .object({
     id: z.number().int().positive().optional(),
     label: z.string().trim().min(1).max(120),
+    banType: z.enum(['soft', 'hard']).default('soft'),
     aliases: z.array(z.string()).default([]),
     ids: z.array(z.string()).default([]),
   })
@@ -124,7 +127,20 @@ export const bannedUsersRouter = createTRPCRouter({
 
   save: permissionProcedure('banned_users.manage')
     .input(saveBannedUserSchema)
-    .mutation(async ({ input }) => {
+    .mutation(async ({ ctx, input }) => {
+      // Hard bans block server access entirely and are gated behind a separate,
+      // deliberately scarce permission. Soft bans only need banned_users.manage.
+      if (
+        input.banType === 'hard' &&
+        !hasPermission(ctx.session.user, 'banned_users.hard_ban')
+      ) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message:
+            'You do not have permission to issue hard (connection) bans.',
+        })
+      }
+
       const aliases = normalizeBannedUserValues(input.aliases)
       const ids = normalizeBannedUserValues(input.ids)
 
@@ -143,7 +159,7 @@ export const bannedUsersRouter = createTRPCRouter({
 
           await tx
             .update(bannedUsers)
-            .set({ label, updatedAt: new Date() })
+            .set({ label, banType: input.banType, updatedAt: new Date() })
             .where(eq(bannedUsers.id, input.id))
 
           await tx
@@ -178,7 +194,7 @@ export const bannedUsersRouter = createTRPCRouter({
 
         const [created] = await tx
           .insert(bannedUsers)
-          .values({ label })
+          .values({ label, banType: input.banType })
           .returning({ id: bannedUsers.id })
 
         if (!created) {

--- a/src/server/banned-users.ts
+++ b/src/server/banned-users.ts
@@ -6,13 +6,21 @@ import {
   bannedUsers,
 } from '@/server/db/schema'
 
+export type BanType = 'soft' | 'hard'
+
 export type BannedUserRegistryEntry = {
   id: number
   label: string
+  banType: BanType
   aliases: string[]
   ids: string[]
   createdAt: Date
   updatedAt: Date
+}
+
+/** Coerce the DB's text column into the BanType union (defaulting to soft). */
+export function asBanType(value: string): BanType {
+  return value === 'hard' ? 'hard' : 'soft'
 }
 
 export type BannedUserMatch = {
@@ -77,6 +85,7 @@ export async function listBannedUserRegistryEntries(
     .select({
       id: bannedUsers.id,
       label: bannedUsers.label,
+      banType: bannedUsers.banType,
       createdAt: bannedUsers.createdAt,
       updatedAt: bannedUsers.updatedAt,
     })
@@ -122,6 +131,7 @@ export async function listBannedUserRegistryEntries(
 
   const hydratedEntries = entries.map((entry) => ({
     ...entry,
+    banType: asBanType(entry.banType),
     aliases: uniqueCaseInsensitive(aliasesByUserId.get(entry.id) ?? []),
     ids: uniqueCaseInsensitive(idsByUserId.get(entry.id) ?? []),
   }))
@@ -176,6 +186,7 @@ export async function getBannedUserRegistryEntry(entryId: number) {
     .select({
       id: bannedUsers.id,
       label: bannedUsers.label,
+      banType: bannedUsers.banType,
       createdAt: bannedUsers.createdAt,
       updatedAt: bannedUsers.updatedAt,
     })
@@ -199,6 +210,7 @@ export async function getBannedUserRegistryEntry(entryId: number) {
 
   return {
     ...entry,
+    banType: asBanType(entry.banType),
     aliases: uniqueCaseInsensitive(aliases.map((alias) => alias.value)),
     ids: uniqueCaseInsensitive(ids.map((row) => row.value)),
   }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -88,6 +88,9 @@ export const usersRelations = relations(users, ({ many }) => ({
 export const bannedUsers = pgTable('banned_users', {
   id: integer('id').primaryKey().generatedByDefaultAsIdentity(),
   label: text('label').notNull(),
+  // 'soft' = notify only (mp-ban-watcher Discord warning); 'hard' = the relay
+  // disconnects the player from the server entirely. Soft is the default.
+  banType: text('ban_type').notNull().default('soft'),
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at')
     .notNull()


### PR DESCRIPTION
Adds a ban-type distinction to the banned-users admin so we can flag a player without tipping them off (soft) or block their server access entirely (hard).

- schema: banned_users.ban_type ('soft' default | 'hard') + migration 0013.
- permission: new banned_users.hard_ban (owner-only by default); the save router rejects hard bans without it. Soft bans need only banned_users.manage.
- UI: soft/hard selector (soft default; hard disabled without permission), a destructive confirmation dialog for hard bans, and a soft/hard badge per row.

Soft bans remain notify-only (mp-ban-watcher Discord warning); hard bans are synced to the relay, which disconnects them.